### PR TITLE
Fix Java 9 figwheel crashing on start

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,8 @@
                  [ysera "1.1.0"]
                  [reagent "0.7.0"]]
 
+  :jvm-opts ["--add-modules" "java.xml.bind"]
+  
   :plugins [[lein-figwheel "0.5.14"]
             [lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]]
 


### PR DESCRIPTION
Java 9 does not automatically load the XML Bind module. Figwheel seems to need it.