### PR TITLE
Revert Java 9 compatibility fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,6 @@
                  [ysera "1.1.0"]
                  [reagent "0.7.0"]]
 
-  :jvm-opts ["--add-modules" "java.xml.bind"]
-  
   :plugins [[lein-figwheel "0.5.14"]
             [lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]]
 


### PR DESCRIPTION
The fix broke things for Java 8 users. (It seems that for now, downgrading to Java 8 is the most reasonable fix for Java 9 incompatibilities.)